### PR TITLE
fix: handle 16-element issue with padding arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-simple-line-chart",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "A fast, interactive, animated and simple line chart component for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/animations/transitionAttach.ts
+++ b/src/animations/transitionAttach.ts
@@ -37,12 +37,22 @@ const useTransitionAttach: animationHook = ({path, duration, enabled}) => {
         const newPathYArray = getPathYArrayFromPath(path?.d || '');
 
         if (path?.data.length && pathXSV.value.length < path?.data.length) {
-            pathXSV.value = new Array(path?.data.length - pathXSV.value.length)
+            let paddedXArray = new Array(path?.data.length - pathXSV.value.length)
                 .fill(0)
                 .concat(pathXSV.value);
-            pathYSV.value = new Array(path?.data.length - pathYSV.value.length)
+            let paddedYArray = new Array(path?.data.length - pathYSV.value.length)
                 .fill(0)
                 .concat(pathYSV.value);
+
+            // reanimated handles arrays with 16 elements as a matrix
+            // so we double the latest elements in the padded arrays too
+            if (paddedXArray.length === 16) {
+                paddedXArray.push(paddedXArray[15]);
+                paddedYArray.push(paddedYArray[15]);
+            }
+
+            pathXSV.value = paddedXArray;
+            pathYSV.value = paddedYArray;
 
             const isInitial = pathXSV.value.length === 0;
 


### PR DESCRIPTION
## Reproduction Steps
  1. Set the `numberOfPoints` state to 5 (or any value that
below 16)
  2. Press the "16 points" button to generate a chart with
  16 points
  3. The chart will break with NaN values

### Demo

https://github.com/user-attachments/assets/1f7e026c-b167-4876-a66d-7eeec69cda69

